### PR TITLE
ci: add support to release Node.js package

### DIFF
--- a/.github/releaser.yml
+++ b/.github/releaser.yml
@@ -5,9 +5,36 @@ on:
     types: [ published, edited ]
 
 jobs:
+
   actions-tagger:
     name: Action Tag
     runs-on: ubuntu-latest
     steps:
+
       - name: Publish tag
         uses: Actions-R-Us/actions-tagger@v2
+
+  publish-npm:
+    name: Publish to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@worksome'
+
+      - name: Install npm dependencies
+        run: npm install
+
+      - name: Publish to GitHub Packages
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JIRA Branch Name Validation Action
 
-A GitHub action for validating if the branch name contains a JIRA id (as format) and whether the same JIRA id is contained in the PR title and commit message(s).
+A GitHub action for ensuring that the branch name contains a valid JIRA id (as format) and whether the same JIRA id is contained in the PR title and commit message(s).
 
 The same code is npm-packaged and used for local pre-commit validation of the branch name, only (via git hooks / husky). The PR title and commits are not checked locally because they are not relevant at this step in the workflow (PR doesn't have to exist when still developing locally and local commit messages can be whatever the developer wants - i.e. before squash and push).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@worksome/jira-branch-name-validator",
   "version": "1.7.5",
-  "description": "A GitHub action for validating if the branch name is contains JIRA id",
+  "description": "A GitHub action for ensuring that the branch name contains a valid JIRA id",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/worksome/jira-branch-name-validator-action.git"
+    "url": "https://github.com/worksome/jira-branch-name-validator-action.git"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Not entirely sure whether we want to do this, but I'd assume every time the action changes, we probably also want to release a new version of the pre-commit script?