### PR TITLE
Update validator.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # JIRA Branch Name Validation Action
 
+NOTE: I adjusted this repo for testing purposes on some personal repos. I would highly recommend going to the soce of worksome/jira-branch-name-validator-action. I am only making slight changes to allow '-' to work in the code. Thank you
+
 A GitHub action for ensuring that the branch name contains a valid JIRA id (as format) and whether the same JIRA id is contained in the PR title and commit message(s).
 
 The same code is npm-packaged and used for local pre-commit validation of the branch name, only (via git hooks / husky). The PR title and commits are not checked locally because they are not relevant at this step in the workflow (PR doesn't have to exist when still developing locally and local commit messages can be whatever the developer wants - i.e. before squash and push).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@worksome/jira-branch-name-validator",
-  "version": "1.8.2",
+  "name": "@FRohrbaugh/jira-branch-name-validator",
+  "version": "1.8.3",
   "description": "A GitHub action for ensuring that the branch name contains a valid JIRA id",
   "main": "index.js",
   "scripts": {
@@ -9,12 +9,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/worksome/jira-branch-name-validator-action.git"
+    "url": "https://github.com/FRohrbaugh/jira-branch-name-validator-action.git"
   },
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/worksome/jira-branch-name-validator-action/issues"
+    "url": "https://github.com/FRohrbaugh/jira-branch-name-validator-action/issues"
   },
   "files": [
     "dist"
@@ -23,9 +23,9 @@
     "branch-validator": "./dist/local/index.js"
   },
   "publishConfig": {
-    "@worksome:registry": "https://npm.pkg.github.com"
+    "@FRohrbaugh:registry": "https://npm.pkg.github.com"
   },
-  "homepage": "https://github.com/worksome/jira-branch-name-validator-action#readme",
+  "homepage": "https://github.com/FRohrbaugh/jira-branch-name-validator-action#readme",
   "dependencies": {
     "@actions/core": "^1.2.6"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@FRohrbaugh/jira-branch-name-validator",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "A GitHub action for ensuring that the branch name contains a valid JIRA id",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@FRohrbaugh/jira-branch-name-validator",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "A GitHub action for ensuring that the branch name contains a valid JIRA id",
   "main": "index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ async function run(): Promise<void> {
         let prValidation = (prTitle.length > 0 && commits.length > 0)
 
         core.info(`Received the following branch name: ${branchName}.`)
-        core.info(`The format should be \`${prefix}-123_fixing-bug\`.`)
+        core.info(`The format should be \`${prefix}-123-fixing-bug\`.`)
 
         let [jiraId, results] = validateBranchName(branchName, prefix)
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -25,8 +25,8 @@ export default function (branchName: string, prefix: string): [string, string[]]
     }
 
     branchName = branchName.substring(rawJiraId.length)
-    if (!branchName.startsWith('_')) {
-        result.push(`Separator after JIRA id is not \`_\`, found ${branchName.substring(0, 1)}.`)
+    if (!branchName.startsWith('-')) {
+        result.push(`Separator after JIRA id is not \`-\`, found ${branchName.substring(0, 1)}.`)
     }
 
     branchName = branchName.substring(1)


### PR DESCRIPTION
Adjusting the requirement of Line 27-29, making it so that '-' can be used instead. Jira uses this as default when making branches from their website/interface.