### PR TITLE
ci(deps): update actions to Node.js 20.x

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -23,12 +23,12 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '20.x'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@worksome'
 


### PR DESCRIPTION
`Actions-R-Us/actions-tagger` doesn't yet support Node.js 20, so I've left that one for now.