### PR TITLE
feat: add support for multiple prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ The same code is npm-packaged and used for local pre-commit validation of the br
 
 **Required** The GitHub API response JSON containing the commits of the PR.
 
+### `prefixes`
+
+**Optional** The allowed Jira project prefixes, separated by commas or whitespace (default is `JIRA`). A branch is valid when it starts with any one of them, e.g. `prefixes: JIRA, INFRA` accepts both `JIRA-123_fixing-bug` and `INFRA-123_fixing-bug`.
+
 ### `prefix`
 
-**Optional** The Jira project prefix (default is `JIRA`).
+**Deprecated** Use `prefixes` instead. A single Jira project prefix. It is only read when `prefixes` is not set.
 
 ***
 
@@ -62,7 +66,7 @@ jobs:
           branch-name: ${{ github.event.pull_request.head.ref }}
           pr-title: ${{ github.event.pull_request.title }}
           commits: ${{ steps.get_pr_commits.outputs.data }}
-          prefix: JIRA
+          prefixes: JIRA, INFRA
 
 ```
 
@@ -93,4 +97,10 @@ The local branch validator can be manually triggered on repositories that use th
 
 ```shell
 node_modules/.bin/branch-validator
+```
+
+By default only the `JIRA` prefix is accepted. Pass `--prefix` (repeatable, or comma-separated) to allow others:
+
+```shell
+node_modules/.bin/branch-validator --prefix JIRA --prefix INFRA
 ```

--- a/action.yml
+++ b/action.yml
@@ -10,9 +10,11 @@ inputs:
   commits:
     description: The Github API response JSON containing the commits of the PR.
     required: true
+  prefixes:
+    description: The allowed Jira project prefixes, separated by commas or whitespace (default is `JIRA`).
   prefix:
-    description: The Jira project prefix.
-    default: 'JIRA'
+    description: 'The Jira project prefix.'
+    deprecationMessage: 'Use `prefixes` instead.'
 runs:
   using: 'node24'
   main: 'dist/github/index.js'

--- a/dist/github/index.js
+++ b/dist/github/index.js
@@ -1920,7 +1920,11 @@ var require_request = __commonJS({
           } else if (typeof val[i] === "object") {
             throw new InvalidArgumentError(`invalid ${key} header`);
           } else {
-            arr.push(`${val[i]}`);
+            const str = `${val[i]}`;
+            if (!isValidHeaderValue(str)) {
+              throw new InvalidArgumentError(`invalid ${key} header`);
+            }
+            arr.push(str);
           }
         }
         val = arr;
@@ -1932,6 +1936,9 @@ var require_request = __commonJS({
         val = "";
       } else {
         val = `${val}`;
+        if (!isValidHeaderValue(val)) {
+          throw new InvalidArgumentError(`invalid ${key} header`);
+        }
       }
       if (headerName === "host") {
         if (request.host !== null) {
@@ -2053,6 +2060,7 @@ var require_dispatcher_base = __commonJS({
       }
       get webSocketOptions() {
         return {
+          maxFragments: this[kWebSocketOptions].maxFragments ?? 131072,
           maxPayloadSize: this[kWebSocketOptions].maxPayloadSize ?? 128 * 1024 * 1024
         };
       }
@@ -5661,6 +5669,7 @@ var require_client_h1 = __commonJS({
       RequestContentLengthMismatchError,
       ResponseContentLengthMismatchError,
       RequestAbortedError,
+      InvalidArgumentError,
       HeadersTimeoutError,
       HeadersOverflowError,
       SocketError,
@@ -5707,6 +5716,9 @@ var require_client_h1 = __commonJS({
     var FastBuffer = Buffer[Symbol.species];
     var addListener = util.addListener;
     var removeAllListeners = util.removeAllListeners;
+    var kIdleSocketValidation = /* @__PURE__ */ Symbol("kIdleSocketValidation");
+    var kIdleSocketValidationTimeout = /* @__PURE__ */ Symbol("kIdleSocketValidationTimeout");
+    var kSocketUsed = /* @__PURE__ */ Symbol("kSocketUsed");
     var extractBody;
     async function lazyllhttp() {
       const llhttpWasmData = process.env.JEST_WORKER_ID ? require_llhttp_wasm() : void 0;
@@ -5869,23 +5881,54 @@ var require_client_h1 = __commonJS({
             currentBufferRef = null;
           }
           const offset = llhttp.llhttp_get_error_pos(this.ptr) - currentBufferPtr;
-          if (ret === constants3.ERROR.PAUSED_UPGRADE) {
-            this.onUpgrade(data.slice(offset));
-          } else if (ret === constants3.ERROR.PAUSED) {
-            this.paused = true;
-            socket.unshift(data.slice(offset));
-          } else if (ret !== constants3.ERROR.OK) {
-            const ptr = llhttp.llhttp_get_error_reason(this.ptr);
-            let message = "";
-            if (ptr) {
-              const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0);
-              message = "Response does not match the HTTP/1.1 protocol (" + Buffer.from(llhttp.memory.buffer, ptr, len).toString() + ")";
+          if (ret !== constants3.ERROR.OK) {
+            const body = data.subarray(offset);
+            if (ret === constants3.ERROR.PAUSED_UPGRADE) {
+              this.onUpgrade(body);
+            } else if (ret === constants3.ERROR.PAUSED) {
+              this.paused = true;
+              socket.unshift(body);
+            } else {
+              throw this.createError(ret, body);
             }
-            throw new HTTPParserError(message, constants3.ERROR[ret], data.slice(offset));
           }
         } catch (err) {
           util.destroy(socket, err);
         }
+      }
+      finish() {
+        assert(currentParser === null);
+        assert(this.ptr != null);
+        assert(!this.paused);
+        const { llhttp } = this;
+        let ret;
+        try {
+          currentParser = this;
+          ret = llhttp.llhttp_finish(this.ptr);
+        } finally {
+          currentParser = null;
+        }
+        if (ret === constants3.ERROR.OK) {
+          return null;
+        }
+        if (ret === constants3.ERROR.PAUSED || ret === constants3.ERROR.PAUSED_UPGRADE) {
+          this.paused = true;
+          return null;
+        }
+        return this.createError(ret, EMPTY_BUF);
+      }
+      createError(ret, data) {
+        const { llhttp, contentLength, bytesRead } = this;
+        if (contentLength && bytesRead !== parseInt(contentLength, 10)) {
+          return new ResponseContentLengthMismatchError();
+        }
+        const ptr = llhttp.llhttp_get_error_reason(this.ptr);
+        let message = "";
+        if (ptr) {
+          const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0);
+          message = "Response does not match the HTTP/1.1 protocol (" + Buffer.from(llhttp.memory.buffer, ptr, len).toString() + ")";
+        }
+        return new HTTPParserError(message, constants3.ERROR[ret], data);
       }
       destroy() {
         assert(this.ptr != null);
@@ -5904,6 +5947,10 @@ var require_client_h1 = __commonJS({
       onMessageBegin() {
         const { socket, client } = this;
         if (socket.destroyed) {
+          return -1;
+        }
+        if (client[kRunning] === 0) {
+          util.destroy(socket, new SocketError("bad response", util.getSocketInfo(socket)));
           return -1;
         }
         const request = client[kQueue][client[kRunningIdx]];
@@ -5983,6 +6030,10 @@ var require_client_h1 = __commonJS({
       onHeadersComplete(statusCode, upgrade, shouldKeepAlive) {
         const { client, socket, headers, statusText } = this;
         if (socket.destroyed) {
+          return -1;
+        }
+        if (client[kRunning] === 0) {
+          util.destroy(socket, new SocketError("bad response", util.getSocketInfo(socket)));
           return -1;
         }
         const request = client[kQueue][client[kRunningIdx]];
@@ -6110,6 +6161,7 @@ var require_client_h1 = __commonJS({
         }
         request.onComplete(headers);
         client[kQueue][client[kRunningIdx]++] = null;
+        socket[kSocketUsed] = true;
         if (socket[kWriting]) {
           assert(client[kRunning] === 0);
           util.destroy(socket, new InformationalError("reset"));
@@ -6153,12 +6205,19 @@ var require_client_h1 = __commonJS({
       socket[kWriting] = false;
       socket[kReset] = false;
       socket[kBlocking] = false;
+      socket[kIdleSocketValidation] = 0;
+      socket[kIdleSocketValidationTimeout] = null;
+      socket[kSocketUsed] = false;
       socket[kParser] = new Parser(client, socket, llhttpInstance);
       addListener(socket, "error", function(err) {
         assert(err.code !== "ERR_TLS_CERT_ALTNAME_INVALID");
         const parser = this[kParser];
         if (err.code === "ECONNRESET" && parser.statusCode && !parser.shouldKeepAlive) {
-          parser.onMessageComplete();
+          const parserErr = parser.finish();
+          if (parserErr) {
+            this[kError] = parserErr;
+            this[kClient][kOnError](parserErr);
+          }
           return;
         }
         this[kError] = err;
@@ -6173,7 +6232,10 @@ var require_client_h1 = __commonJS({
       addListener(socket, "end", function() {
         const parser = this[kParser];
         if (parser.statusCode && !parser.shouldKeepAlive) {
-          parser.onMessageComplete();
+          const parserErr = parser.finish();
+          if (parserErr) {
+            util.destroy(this, parserErr);
+          }
           return;
         }
         util.destroy(this, new SocketError("other side closed", util.getSocketInfo(this)));
@@ -6181,9 +6243,10 @@ var require_client_h1 = __commonJS({
       addListener(socket, "close", function() {
         const client2 = this[kClient];
         const parser = this[kParser];
+        clearIdleSocketValidation(this);
         if (parser) {
           if (!this[kError] && parser.statusCode && !parser.shouldKeepAlive) {
-            parser.onMessageComplete();
+            this[kError] = parser.finish() || this[kError];
           }
           this[kParser].destroy();
           this[kParser] = null;
@@ -6232,7 +6295,7 @@ var require_client_h1 = __commonJS({
           return socket.destroyed;
         },
         busy(request) {
-          if (socket[kWriting] || socket[kReset] || socket[kBlocking]) {
+          if (socket[kWriting] || socket[kReset] || socket[kBlocking] || socket[kIdleSocketValidation] === 1) {
             return true;
           }
           if (request) {
@@ -6250,6 +6313,24 @@ var require_client_h1 = __commonJS({
         }
       };
     }
+    function clearIdleSocketValidation(socket) {
+      if (socket[kIdleSocketValidationTimeout]) {
+        clearTimeout(socket[kIdleSocketValidationTimeout]);
+        socket[kIdleSocketValidationTimeout] = null;
+      }
+      socket[kIdleSocketValidation] = 0;
+    }
+    function scheduleIdleSocketValidation(client, socket) {
+      socket[kIdleSocketValidation] = 1;
+      socket[kIdleSocketValidationTimeout] = setTimeout(() => {
+        socket[kIdleSocketValidationTimeout] = null;
+        socket[kIdleSocketValidation] = 2;
+        if (client[kSocket] === socket && !socket.destroyed) {
+          client[kResume]();
+        }
+      }, 0);
+      socket[kIdleSocketValidationTimeout].unref?.();
+    }
     function resumeH1(client) {
       const socket = client[kSocket];
       if (socket && !socket.destroyed) {
@@ -6261,6 +6342,29 @@ var require_client_h1 = __commonJS({
         } else if (socket[kNoRef] && socket.ref) {
           socket.ref();
           socket[kNoRef] = false;
+        }
+        if (client[kRunning] === 0 && client[kPending] > 0 && socket[kSocketUsed]) {
+          if (socket[kIdleSocketValidation] === 0) {
+            scheduleIdleSocketValidation(client, socket);
+            socket[kParser].readMore();
+            if (socket.destroyed) {
+              return;
+            }
+            return;
+          }
+          if (socket[kIdleSocketValidation] === 1) {
+            socket[kParser].readMore();
+            if (socket.destroyed) {
+              return;
+            }
+            return;
+          }
+        }
+        if (client[kRunning] === 0) {
+          socket[kParser].readMore();
+          if (socket.destroyed) {
+            return;
+          }
         }
         if (client[kSize] === 0) {
           if (socket[kParser].timeoutType !== TIMEOUT_KEEP_ALIVE) {
@@ -6292,8 +6396,16 @@ var require_client_h1 = __commonJS({
         }
         body = bodyStream.stream;
         contentLength = bodyStream.length;
-      } else if (util.isBlobLike(body) && request.contentType == null && body.type) {
-        headers.push("content-type", body.type);
+      } else if (util.isBlobLike(body) && request.contentType == null) {
+        const contentType = body.type;
+        if (contentType) {
+          const contentTypeValue = `${contentType}`;
+          if (!util.isValidHeaderValue(contentTypeValue)) {
+            util.errorRequest(client, request, new InvalidArgumentError("invalid content-type header"));
+            return false;
+          }
+          headers.push("content-type", contentTypeValue);
+        }
       }
       if (body && typeof body.read === "function") {
         body.read(0);
@@ -6314,6 +6426,7 @@ var require_client_h1 = __commonJS({
         process.emitWarning(new RequestContentLengthMismatchError());
       }
       const socket = client[kSocket];
+      clearIdleSocketValidation(socket);
       const abort = (err) => {
         if (request.aborted || request.completed) {
           return;
@@ -8844,6 +8957,24 @@ var require_retry_handler = __commonJS({
       const current = Date.now();
       return new Date(retryAfter).getTime() - current;
     }
+    function validatePartialResponseContentLength(headers, range, statusCode, retryCount) {
+      const contentLength = headers["content-length"];
+      if (contentLength == null) {
+        return null;
+      }
+      if (!Number.isFinite(range.start) || !Number.isFinite(range.end)) {
+        return null;
+      }
+      const length = Number(contentLength);
+      const expectedLength = range.end - range.start + 1;
+      if (!Number.isFinite(length) || length !== expectedLength) {
+        return new RequestRetryError("Content-Length mismatch", statusCode, {
+          headers,
+          data: { count: retryCount }
+        });
+      }
+      return null;
+    }
     var RetryHandler = class _RetryHandler {
       constructor(opts, handlers) {
         const { retryOptions, ...dispatchOpts } = opts;
@@ -9016,6 +9147,11 @@ var require_retry_handler = __commonJS({
             );
             return false;
           }
+          const contentLengthError = validatePartialResponseContentLength(headers, contentRange, statusCode, this.retryCount);
+          if (contentLengthError != null) {
+            this.abort(contentLengthError);
+            return false;
+          }
           const { start, size, end = size - 1 } = contentRange;
           assert(this.start === start, "content-range mismatch");
           assert(this.end == null || this.end === end, "content-range mismatch");
@@ -9032,6 +9168,11 @@ var require_retry_handler = __commonJS({
                 resume,
                 statusMessage
               );
+            }
+            const contentLengthError = validatePartialResponseContentLength(headers, range, statusCode, this.retryCount);
+            if (contentLengthError != null) {
+              this.abort(contentLengthError);
+              return false;
             }
             const { start, size, end = size - 1 } = range;
             assert(
@@ -15878,14 +16019,48 @@ var require_util6 = __commonJS({
       for (let i = 0; i < path.length; ++i) {
         const code = path.charCodeAt(i);
         if (code < 32 || // exclude CTLs (0-31)
-        code === 127 || // DEL
+        code > 126 || // exclude DEL and non-ascii
         code === 59) {
           throw new Error("Invalid cookie path");
         }
       }
     }
+    function isLetterOrDigit(code) {
+      return code >= 48 && code <= 57 || // 0-9
+      code >= 65 && code <= 90 || // A-Z
+      code >= 97 && code <= 122;
+    }
     function validateCookieDomain(domain) {
-      if (domain.startsWith("-") || domain.endsWith(".") || domain.endsWith("-")) {
+      if (domain === " ") {
+        return;
+      }
+      if (domain.length > 255) {
+        throw new Error("Invalid cookie domain");
+      }
+      let labelLength = 0;
+      for (let i = 0; i < domain.length; ++i) {
+        const code = domain.charCodeAt(i);
+        if (code === 46) {
+          if (labelLength === 0) {
+            throw new Error("Invalid cookie domain");
+          }
+          if (domain.charCodeAt(i - 1) === 45) {
+            throw new Error("Invalid cookie domain");
+          }
+          labelLength = 0;
+          continue;
+        }
+        if (labelLength === 0 && !isLetterOrDigit(code)) {
+          throw new Error("Invalid cookie domain");
+        }
+        if (!isLetterOrDigit(code) && code !== 45) {
+          throw new Error("Invalid cookie domain");
+        }
+        if (++labelLength > 63) {
+          throw new Error("Invalid cookie domain");
+        }
+      }
+      if (labelLength === 0 || domain.charCodeAt(domain.length - 1) === 45) {
         throw new Error("Invalid cookie domain");
       }
     }
@@ -15968,7 +16143,11 @@ var require_util6 = __commonJS({
           throw new Error("Invalid unparsed");
         }
         const [key, ...value] = part.split("=");
-        out.push(`${key.trim()}=${value.join("=")}`);
+        const trimmedKey = key.trim();
+        const joinedValue = value.join("=");
+        validateCookieName(trimmedKey);
+        validateCookieValue(joinedValue);
+        out.push(`${trimmedKey}=${joinedValue}`);
       }
       return out.join("; ");
     }
@@ -16098,18 +16277,14 @@ var require_parse = __commonJS({
       } else if (attributeNameLowercase === "httponly") {
         cookieAttributeList.httpOnly = true;
       } else if (attributeNameLowercase === "samesite") {
-        let enforcement = "Default";
         const attributeValueLowercase = attributeValue.toLowerCase();
-        if (attributeValueLowercase.includes("none")) {
-          enforcement = "None";
+        if (attributeValueLowercase === "none") {
+          cookieAttributeList.sameSite = "None";
+        } else if (attributeValueLowercase === "strict") {
+          cookieAttributeList.sameSite = "Strict";
+        } else if (attributeValueLowercase === "lax") {
+          cookieAttributeList.sameSite = "Lax";
         }
-        if (attributeValueLowercase.includes("strict")) {
-          enforcement = "Strict";
-        }
-        if (attributeValueLowercase.includes("lax")) {
-          enforcement = "Lax";
-        }
-        cookieAttributeList.sameSite = enforcement;
       } else {
         cookieAttributeList.unparsed ??= [];
         cookieAttributeList.unparsed.push(`${attributeName}=${attributeValue}`);
@@ -17131,6 +17306,10 @@ var require_receiver = __commonJS({
     var { closeWebSocketConnection } = require_connection();
     var { PerMessageDeflate } = require_permessage_deflate();
     var { MessageSizeExceededError } = require_errors();
+    function failWebsocketConnectionWithCode(ws, code, reason) {
+      closeWebSocketConnection(ws, code, reason, Buffer.byteLength(reason));
+      failWebsocketConnection(ws, reason);
+    }
     var ByteParser = class extends Writable {
       #buffers = [];
       #fragmentsBytes = 0;
@@ -17142,16 +17321,19 @@ var require_receiver = __commonJS({
       /** @type {Map<string, PerMessageDeflate>} */
       #extensions;
       /** @type {number} */
+      #maxFragments;
+      /** @type {number} */
       #maxPayloadSize;
       /**
        * @param {import('./websocket').WebSocket} ws
        * @param {Map<string, string>|null} extensions
-       * @param {{ maxPayloadSize?: number }} [options]
+       * @param {{ maxFragments?: number, maxPayloadSize?: number }} [options]
        */
       constructor(ws, extensions, options = {}) {
         super();
         this.ws = ws;
         this.#extensions = extensions == null ? /* @__PURE__ */ new Map() : extensions;
+        this.#maxFragments = options.maxFragments ?? 0;
         this.#maxPayloadSize = options.maxPayloadSize ?? 0;
         if (this.#extensions.has("permessage-deflate")) {
           this.#extensions.set("permessage-deflate", new PerMessageDeflate(extensions, options));
@@ -17168,8 +17350,8 @@ var require_receiver = __commonJS({
         this.run(callback);
       }
       #validatePayloadLength() {
-        if (this.#maxPayloadSize > 0 && !isControlFrame(this.#info.opcode) && this.#info.payloadLength > this.#maxPayloadSize) {
-          failWebsocketConnection(this.ws, "Payload size exceeds maximum allowed size");
+        if (this.#maxPayloadSize > 0 && !isControlFrame(this.#info.opcode) && this.#info.payloadLength + this.#fragmentsBytes > this.#maxPayloadSize) {
+          failWebsocketConnectionWithCode(this.ws, 1009, "Payload size exceeds maximum allowed size");
           return false;
         }
         return true;
@@ -17285,9 +17467,11 @@ var require_receiver = __commonJS({
               this.#state = parserStates.INFO;
             } else {
               if (!this.#info.compressed) {
-                this.writeFragments(body);
+                if (!this.writeFragments(body)) {
+                  return;
+                }
                 if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
-                  failWebsocketConnection(this.ws, new MessageSizeExceededError().message);
+                  failWebsocketConnectionWithCode(this.ws, 1009, new MessageSizeExceededError().message);
                   return;
                 }
                 if (!this.#info.fragmented && this.#info.fin) {
@@ -17300,12 +17484,15 @@ var require_receiver = __commonJS({
                   this.#info.fin,
                   (error2, data) => {
                     if (error2) {
-                      failWebsocketConnection(this.ws, error2.message);
+                      const code = error2 instanceof MessageSizeExceededError ? 1009 : 1007;
+                      failWebsocketConnectionWithCode(this.ws, code, error2.message);
                       return;
                     }
-                    this.writeFragments(data);
+                    if (!this.writeFragments(data)) {
+                      return;
+                    }
                     if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
-                      failWebsocketConnection(this.ws, new MessageSizeExceededError().message);
+                      failWebsocketConnectionWithCode(this.ws, 1009, new MessageSizeExceededError().message);
                       return;
                     }
                     if (!this.#info.fin) {
@@ -17363,8 +17550,13 @@ var require_receiver = __commonJS({
         return buffer;
       }
       writeFragments(fragment) {
+        if (this.#maxFragments > 0 && this.#fragments.length === this.#maxFragments) {
+          failWebsocketConnectionWithCode(this.ws, 1008, "Too many message fragments");
+          return false;
+        }
         this.#fragmentsBytes += fragment.length;
         this.#fragments.push(fragment);
+        return true;
       }
       consumeFragments() {
         const fragments = this.#fragments;
@@ -17814,8 +18006,11 @@ var require_websocket = __commonJS({
        */
       #onConnectionEstablished(response, parsedExtensions) {
         this[kResponse] = response;
-        const maxPayloadSize = this[kController]?.dispatcher?.webSocketOptions?.maxPayloadSize;
+        const webSocketOptions = this[kController]?.dispatcher?.webSocketOptions;
+        const maxFragments = webSocketOptions?.maxFragments;
+        const maxPayloadSize = webSocketOptions?.maxPayloadSize;
         const parser = new ByteParser(this, parsedExtensions, {
+          maxFragments,
           maxPayloadSize
         });
         parser.on("drain", onParserDrain);
@@ -18629,11 +18824,23 @@ var require_undici = __commonJS({
 });
 
 // src/validator.ts
-function validator_default(branchName, prefix) {
-  let result = [];
-  if (!branchName.startsWith(prefix)) {
-    result.push(`Branch doesn't start with \`${prefix}\` prefix, found ${branchName}.`);
+var DEFAULT_PREFIXES = ["JIRA"];
+function parsePrefixes(value) {
+  return value.split(/[\s,]+/).map((prefix) => prefix.trim()).filter((prefix) => prefix.length > 0);
+}
+function formatPrefixes(prefixes) {
+  return prefixes.map((prefix) => `\`${prefix}\``).join(", ");
+}
+function validator_default(branchName, prefixes) {
+  if (prefixes.length === 0) {
+    throw new Error("At least one prefix has to be provided.");
   }
+  let result = [];
+  const matchedPrefix = prefixes.filter((prefix2) => branchName.startsWith(prefix2)).sort((a, b) => b.length - a.length)[0];
+  if (matchedPrefix === void 0) {
+    result.push(prefixes.length === 1 ? `Branch doesn't start with \`${prefixes[0]}\` prefix, found ${branchName}.` : `Branch doesn't start with one of the ${formatPrefixes(prefixes)} prefixes, found ${branchName}.`);
+  }
+  const prefix = matchedPrefix ?? (branchName.match(/^[a-zA-Z]+/) ?? [""])[0];
   branchName = branchName.substring(prefix.length);
   if (!branchName.startsWith("-")) {
     result.push(`Separator after prefix is not \`-\`, found ${branchName.substring(0, 1)}.`);
@@ -19136,11 +19343,18 @@ async function run() {
     let branchName = getInput("branch-name");
     let prTitle = getInput("pr-title");
     let commits = getInput("commits");
-    let prefix = getInput("prefix");
+    let prefixes = parsePrefixes(getInput("prefixes"));
+    if (prefixes.length === 0) {
+      prefixes = parsePrefixes(getInput("prefix"));
+    }
+    if (prefixes.length === 0) {
+      prefixes = DEFAULT_PREFIXES;
+    }
     let prValidation = prTitle.length > 0 && commits.length > 0;
     info(`Received the following branch name: ${branchName}.`);
-    info(`The format should be \`${prefix}-123_fixing-bug\`.`);
-    let [jiraId, results] = validator_default(branchName, prefix);
+    info(`The format should be \`${prefixes[0]}-123_fixing-bug\`.`);
+    info(`The allowed prefixes are ${formatPrefixes(prefixes)}.`);
+    let [jiraId, results] = validator_default(branchName, prefixes);
     info(`Extracted the following JIRA ID from branch name: ${jiraId}`);
     if (prValidation) {
       info(`Received the following PR title: ${prTitle}`);

--- a/dist/local/index.js
+++ b/dist/local/index.js
@@ -5,11 +5,23 @@
 var import_child_process = require("child_process");
 
 // src/validator.ts
-function validator_default(branchName, prefix) {
-  let result = [];
-  if (!branchName.startsWith(prefix)) {
-    result.push(`Branch doesn't start with \`${prefix}\` prefix, found ${branchName}.`);
+var DEFAULT_PREFIXES = ["JIRA"];
+function parsePrefixes(value) {
+  return value.split(/[\s,]+/).map((prefix) => prefix.trim()).filter((prefix) => prefix.length > 0);
+}
+function formatPrefixes(prefixes) {
+  return prefixes.map((prefix) => `\`${prefix}\``).join(", ");
+}
+function validator_default(branchName, prefixes) {
+  if (prefixes.length === 0) {
+    throw new Error("At least one prefix has to be provided.");
   }
+  let result = [];
+  const matchedPrefix = prefixes.filter((prefix2) => branchName.startsWith(prefix2)).sort((a, b) => b.length - a.length)[0];
+  if (matchedPrefix === void 0) {
+    result.push(prefixes.length === 1 ? `Branch doesn't start with \`${prefixes[0]}\` prefix, found ${branchName}.` : `Branch doesn't start with one of the ${formatPrefixes(prefixes)} prefixes, found ${branchName}.`);
+  }
+  const prefix = matchedPrefix ?? (branchName.match(/^[a-zA-Z]+/) ?? [""])[0];
   branchName = branchName.substring(prefix.length);
   if (!branchName.startsWith("-")) {
     result.push(`Separator after prefix is not \`-\`, found ${branchName.substring(0, 1)}.`);
@@ -40,8 +52,9 @@ function validator_default(branchName, prefix) {
 
 // src/pre-commit.ts
 async function run() {
+  const prefixes = parsePrefixArguments(process.argv.slice(2));
   const branchName = await getCurrentBranch();
-  const [, results] = validator_default(branchName, "JIRA");
+  const [, results] = validator_default(branchName, prefixes);
   results.forEach((message) => {
     console.log(message);
   });
@@ -49,6 +62,34 @@ async function run() {
     process.exit(1);
   }
   process.exit(0);
+}
+function parsePrefixArguments(args) {
+  const prefixes = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--prefix" || arg === "-p") {
+      const value = args[++i];
+      if (value === void 0 || value.startsWith("-")) {
+        throw new Error(`The "${arg}" option requires a value, e.g. "${arg} JIRA".`);
+      }
+      prefixes.push(...parseRequiredPrefixes(arg, value));
+      continue;
+    }
+    if (arg.startsWith("--prefix=") || arg.startsWith("-p=")) {
+      const separator = arg.indexOf("=");
+      prefixes.push(...parseRequiredPrefixes(arg.substring(0, separator), arg.substring(separator + 1)));
+      continue;
+    }
+    throw new Error(`Unknown option "${arg}". Usage: branch-validator [--prefix <prefix>]...`);
+  }
+  return prefixes.length > 0 ? prefixes : DEFAULT_PREFIXES;
+}
+function parseRequiredPrefixes(option, value) {
+  const prefixes = parsePrefixes(value);
+  if (prefixes.length === 0) {
+    throw new Error(`The "${option}" option requires a value, e.g. "${option} JIRA".`);
+  }
+  return prefixes;
 }
 async function getCurrentBranch() {
   const { stdout, stderr } = await exec("git branch");
@@ -79,4 +120,7 @@ async function exec(command, options = { cwd: process.cwd() }) {
     });
   });
 }
-run();
+run().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worksome/jira-branch-name-validator",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "A GitHub action for ensuring that the branch name contains a valid JIRA id",
   "main": "index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import validateBranchName from './validator';
+import validateBranchName, {DEFAULT_PREFIXES, formatPrefixes, parsePrefixes} from './validator';
 import checkJiraIdConsistency from './jira-id-consistency-check'
 import * as core from '@actions/core';
 
@@ -7,14 +7,24 @@ async function run(): Promise<void> {
         let branchName = core.getInput('branch-name')
         let prTitle = core.getInput('pr-title')
         let commits = core.getInput('commits')
-        let prefix = core.getInput('prefix')
+        let prefixes = parsePrefixes(core.getInput('prefixes'))
+
+        if (prefixes.length === 0) {
+            // `prefix` is the deprecated, single-value spelling of `prefixes`.
+            prefixes = parsePrefixes(core.getInput('prefix'))
+        }
+
+        if (prefixes.length === 0) {
+            prefixes = DEFAULT_PREFIXES
+        }
 
         let prValidation = (prTitle.length > 0 && commits.length > 0)
 
         core.info(`Received the following branch name: ${branchName}.`)
-        core.info(`The format should be \`${prefix}-123_fixing-bug\`.`)
+        core.info(`The format should be \`${prefixes[0]}-123_fixing-bug\`.`)
+        core.info(`The allowed prefixes are ${formatPrefixes(prefixes)}.`)
 
-        let [jiraId, results] = validateBranchName(branchName, prefix)
+        let [jiraId, results] = validateBranchName(branchName, prefixes)
 
         core.info(`Extracted the following JIRA ID from branch name: ${jiraId}`)
 

--- a/src/pre-commit.ts
+++ b/src/pre-commit.ts
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
 import {exec as cpExec} from 'child_process';
-import validateBranchName from './validator';
+import validateBranchName, {DEFAULT_PREFIXES, parsePrefixes} from './validator';
 
 async function run(): Promise<void> {
+    const prefixes = parsePrefixArguments(process.argv.slice(2));
     const branchName = await getCurrentBranch();
-    const [, results] = validateBranchName(branchName, 'JIRA');
+    const [, results] = validateBranchName(branchName, prefixes);
 
     results.forEach(message => {
         console.log(message);
@@ -16,6 +17,48 @@ async function run(): Promise<void> {
     }
 
     process.exit(0)
+}
+
+function parsePrefixArguments(args: string[]): string[] {
+    const prefixes: string[] = []
+
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i]
+
+        if (arg === '--prefix' || arg === '-p') {
+            const value = args[++i]
+
+            if (value === undefined || value.startsWith('-')) {
+                throw new Error(`The "${arg}" option requires a value, e.g. "${arg} JIRA".`)
+            }
+
+            prefixes.push(...parseRequiredPrefixes(arg, value))
+
+            continue
+        }
+
+        if (arg.startsWith('--prefix=') || arg.startsWith('-p=')) {
+            const separator = arg.indexOf('=')
+
+            prefixes.push(...parseRequiredPrefixes(arg.substring(0, separator), arg.substring(separator + 1)))
+
+            continue
+        }
+
+        throw new Error(`Unknown option "${arg}". Usage: branch-validator [--prefix <prefix>]...`)
+    }
+
+    return prefixes.length > 0 ? prefixes : DEFAULT_PREFIXES
+}
+
+function parseRequiredPrefixes(option: string, value: string): string[] {
+    const prefixes = parsePrefixes(value)
+
+    if (prefixes.length === 0) {
+        throw new Error(`The "${option}" option requires a value, e.g. "${option} JIRA".`)
+    }
+
+    return prefixes
 }
 
 async function getCurrentBranch(): Promise<string> {
@@ -61,4 +104,8 @@ async function exec(
     });
 }
 
-run();
+run().catch((error: any) => {
+    console.error(error instanceof Error ? error.message : error);
+
+    process.exit(1)
+});

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,10 +1,37 @@
-export default function (branchName: string, prefix: string): [string, string[]] {
+export const DEFAULT_PREFIXES: string[] = ['JIRA']
+
+export function parsePrefixes(value: string): string[] {
+    return value
+        .split(/[\s,]+/)
+        .map(prefix => prefix.trim())
+        .filter(prefix => prefix.length > 0)
+}
+
+export function formatPrefixes(prefixes: string[]): string {
+    return prefixes.map(prefix => `\`${prefix}\``).join(', ')
+}
+
+export default function (branchName: string, prefixes: string[]): [string, string[]] {
+    if (prefixes.length === 0) {
+        throw new Error('At least one prefix has to be provided.')
+    }
 
     let result: string[] = []
 
-    if (!branchName.startsWith(prefix)) {
-        result.push(`Branch doesn't start with \`${prefix}\` prefix, found ${branchName}.`)
+    // Longest match first, so that `JIRA` doesn't shadow a `JIRAX` prefix.
+    const matchedPrefix = prefixes
+        .filter(prefix => branchName.startsWith(prefix))
+        .sort((a, b) => b.length - a.length)[0]
+
+    if (matchedPrefix === undefined) {
+        result.push(prefixes.length === 1
+            ? `Branch doesn't start with \`${prefixes[0]}\` prefix, found ${branchName}.`
+            : `Branch doesn't start with one of the ${formatPrefixes(prefixes)} prefixes, found ${branchName}.`)
     }
+
+    // Without a match, fall back to whatever the branch itself leads with, so that the
+    // remaining rules are reported against the actual branch name instead of an offset one.
+    const prefix = matchedPrefix ?? (branchName.match(/^[a-zA-Z]+/) ?? [''])[0]
 
     branchName = branchName.substring(prefix.length)
     if (!branchName.startsWith('-')) {
@@ -40,4 +67,3 @@ export default function (branchName: string, prefix: string): [string, string[]]
 
     return [`${prefix}-${jiraId}`, result]
 }
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configure multiple Jira project prefixes using the new `prefixes` action input.
  * Prefixes may be separated by commas or whitespace.
  * CLI validation now supports multiple `--prefix` or `-p` options.
  * Defaults to the `JIRA` prefix when none are provided.

* **Bug Fixes**
  * Improved validation for overlapping prefixes and clearer error messages.
  * CLI errors now display a user-friendly message and exit cleanly.

* **Documentation**
  * Updated examples and testing instructions for multi-prefix validation.
  * Marked the single `prefix` input as deprecated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->